### PR TITLE
Edge

### DIFF
--- a/lib/spawn.rb
+++ b/lib/spawn.rb
@@ -119,7 +119,8 @@ module Spawn
       options[:method].call(proc { yield })
     elsif options[:method] == :thread
       # for versions before 2.2, check for allow_concurrency
-      if RAILS_2_2 || ActiveRecord::Base.allow_concurrency
+     if RAILS_2_2 || ActiveRecord::Base.respond_to?(:allow_concurrency) ? 
+                       ActiveRecord::Base.allow_concurrency :  Rails.application.config.allow_concurrency
         thread_it(options) { yield }
       else
         @@logger.error("spawn(:method=>:thread) only allowed when allow_concurrency=true")


### PR DESCRIPTION
ActiveRecord::Base.allow_concurrency has been removed from Rails 3.0.3 - changed to check for this method
and call Rails.application.config.allow_concurrency if it isn't present
