### PR TITLE
Make spawning with memcache in rails 3.2.X work properly again - reset method on Rails.cache was not being defined

### DIFF
--- a/lib/patches.rb
+++ b/lib/patches.rb
@@ -130,6 +130,6 @@ if need_passenger_patch
   end
 end
 
-if defined?(::ActiveSupport::Cache::MemCacheStore) && ::ActiveSupport::Cache.autoload?(:MemCacheStore).nil?
+if defined?(::ActiveSupport::Cache::MemCacheStore)
   ::ActiveSupport::Cache::MemCacheStore.delegate :reset, :to => :@data
 end


### PR DESCRIPTION
We were seeing the classic connection sharing problems with memcache as Rails.cache.reset was not being called.

It seems odd to check that the class has been autoloaded?
  At least in rails 3.2 when this gem is loaded, ActiveSupport::Cache is not autoloaded yet,
  hence the second condition is false. Remove that condition as it doesn't seem needed
