### PR TITLE
This fixes undefined method alive? when using :fork

### DIFF
--- a/lib/spawnling.rb
+++ b/lib/spawnling.rb
@@ -186,7 +186,7 @@ class Spawnling
     Process.detach(child)
 
     # remove dead children from the target list to avoid memory leaks
-    @@punks.delete_if {|punk| !alive?(punk)}
+    @@punks.delete_if {|punk| !Spawn.alive?(punk)}
 
     # mark this child for death when this process dies
     if options[:kill]


### PR DESCRIPTION
The problem is that Spawn.alive? is a class method and #fork_it is an instance method (which got rearranged a few commits ago).  I've changed the call to use the class method version.
