### PR TITLE
Allow Process.detach to be optionally skipped in fork_it

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,9 @@ The options you can pass to spawn are:
   <tr><td>:kill</td><td>boolean value indicating whether the parent should kill the spawned process
    when it exits (only valid when :method => :fork)</td></tr>
   <tr><td>:argv</td><td>string to override the process name</td></tr>
+  <tr><td>:detach</td><td>boolean value indicating whether the parent should Process.detach the
+   spawned processes. (defaults to true).  You *must* Spawnling.wait or Process.wait if you use this.
+   Changing this allows you to wait for the first child to exit instead of waiting for all of them.</td></tr>
 </table>
 
 Any option to spawn can be set as a default so that you don't have to pass them in

--- a/lib/spawnling.rb
+++ b/lib/spawnling.rb
@@ -16,7 +16,8 @@ class Spawnling
     :method => ((RUBY_PLATFORM =~ /(win32|mingw32|java)/) ? :thread : :fork),
     :nice   => nil,
     :kill   => false,
-    :argv   => nil
+    :argv   => nil,
+    :detach => true
   }
 
   # things to close in child process
@@ -42,6 +43,9 @@ class Spawnling
   #   :kill   => whether or not the parent process will kill the
   #              spawned child process when the parent exits
   #   :argv   => changes name of the spawned process as seen in ps
+  #   :detach => whether or not Process.detach is called for spawned child
+  #              processes.  You must wait for children on your own if you
+  #              set this to false
   def self.default_options(options = {})
     @@default_options.merge!(options)
     @@logger.info "spawn> default options = #{options.inspect}" if @@logger
@@ -183,7 +187,7 @@ class Spawnling
     end
 
     # detach from child process (parent may still wait for detached process if they wish)
-    Process.detach(child)
+    Process.detach(child) if options[:detach]
 
     # remove dead children from the target list to avoid memory leaks
     @@punks.delete_if {|punk| !Spawn.alive?(punk)}


### PR DESCRIPTION
This patch allows you to request that Process.detach not be called when using the :fork method.
This is something I need so that I can call Process.wait myself and know when the first child process completed.
