### PR TITLE
Updates rspec version

### DIFF
--- a/spawnling.gemspec
+++ b/spawnling.gemspec
@@ -28,7 +28,7 @@ threads (see lib/patches.rb).}
 
   s.add_development_dependency 'bundler'
   s.add_development_dependency 'rake'
-  s.add_development_dependency 'rspec', '~> 2.0'
+  s.add_development_dependency 'rspec', '~> 3.0'
   s.add_development_dependency 'simplecov'
   s.add_development_dependency 'simplecov-rcov'
   s.add_development_dependency 'coveralls'


### PR DESCRIPTION
This avoids hitting the "undefined method `last_comment'" error.
last_comment has been depreciated in rake so updating rspec fixes that.

The last build failed because of this. A stack overflow article helped me track this down https://stackoverflow.com/questions/35893584/nomethoderror-undefined-method-last-comment-after-upgrading-to-rake-11