### PR TITLE
Only check for MemCacheStore if required

### DIFF
--- a/lib/patches.rb
+++ b/lib/patches.rb
@@ -137,7 +137,7 @@ end
 if defined?(Rails)
   class SpawnlingCache < Rails::Railtie
     initializer "cache" do
-      if defined?(::ActiveSupport::Cache::MemCacheStore) && Rails.cache.class.name == 'ActiveSupport::Cache::MemCacheStore'
+      if Rails.cache.class.name == 'ActiveSupport::Cache::MemCacheStore' && defined?(::ActiveSupport::Cache::MemCacheStore)
         ::ActiveSupport::Cache::MemCacheStore.delegate :reset, :to => :@data
       end
     end


### PR DESCRIPTION
```
defined?(::ActiveSupport::Cache::MemCacheStore)
```
This code causes `activesupport-5.2.x/lib/active_support/cache/mem_cache_store.rb` to be loaded which then reports error `You don't have dalli installed in your application. Please add it to your Gemfile and run bundle install`.

By checking for class existence only if it's selected, this error message can be avoided.